### PR TITLE
Fix import path for bitcask

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/acteek/telegram-bot-api v4.6.5-0.20200203170103-fcefac771666+incompatible
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prologic/bitcask v0.3.5
+	git.mills.io/prologic/bitcask v0.3.5
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/tidwall/gjson v1.4.0
 	golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a // indirect

--- a/store.go
+++ b/store.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 )
 
 //Store it's a wraper for Bitcask store


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇